### PR TITLE
Fix deployment for FreeBSD

### DIFF
--- a/Mage/Task/BuiltIn/Deployment/ReleaseTask.php
+++ b/Mage/Task/BuiltIn/Deployment/ReleaseTask.php
@@ -90,7 +90,7 @@ class ReleaseTask extends AbstractTask implements IsReleaseAware, SkipOnOverride
             if ($resultFetch && $userGroup != '') {
                 $command.= " && chown -h {$userGroup} {$tmplink}";
             }
-            $command.= " && mv -f {$tmplink} {$symlink}";
+            $command.= " && rm -rf {$symlink} && mv -f {$tmplink} {$symlink}";
             $result = $this->runCommandRemote($command);
 
             if ($result) {


### PR DESCRIPTION
Remove existing symlink for `current` folder before generating a new one, otherwise it would not be overwritten.
